### PR TITLE
Update to get dynamically api port for websocket by @BZHunt

### DIFF
--- a/frontend/src/boot/socketio.js
+++ b/frontend/src/boot/socketio.js
@@ -3,7 +3,7 @@ import {Loading} from 'quasar'
 import { $t } from '@/boot/i18n'
 
 export default ({ Vue }) => {
-    var socket = io(`${window.location.protocol}//${window.location.hostname}:${process.env.API_PORT}`);
+    var socket = io(`${window.location.protocol}//${window.location.hostname}${window.location.port != '' ? ':' + window.location.port : ''}`);
 
     socket.on('disconnect', (error) => {
         Loading.show({


### PR DESCRIPTION
This commit get the SocketIO port dynamically from the window object instead of the Env variable.

Based on https://github.com/pwndoc/pwndoc/pull/412/ by @BZHunt and @BorysekOndrej

