### PR TITLE
Open TemporalEnvironnementalScoreCvss by default

### DIFF
--- a/frontend/src/components/cvsscalculator.vue
+++ b/frontend/src/components/cvsscalculator.vue
@@ -285,6 +285,7 @@
             </div>
         </q-card-section>
         <q-expansion-item 
+        default-opened
         :label="$t('cvss.temporalEnvironmentalTitle')"
         header-class="bg-blue-grey-5 text-white" 
         expand-icon-class="text-white">


### PR DESCRIPTION
Open  the <q-expansion-item of the temporal / Environmental cvss score by default