### PR TITLE
feature: add basic API documentation exposed at /api-docs

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
         "otpauth": "^7.0.6",
         "qrcode": "^1.4.4",
         "socket.io": "^4.4.1",
+        "swagger-ui-express": "^4.6.0",
         "winston": "^2.3.1",
         "xml": "^1.0.1"
       },
@@ -39,7 +40,8 @@
         "babel-jest": "^26.0.1",
         "jest": "^26.0.1",
         "nodemon": "^1.19.4",
-        "npm": "^6.12.0"
+        "npm": "^6.12.0",
+        "swagger-autogen": "^2.22.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4085,9 +4087,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -6658,19 +6660,22 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -8210,13 +8215,10 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -8607,9 +8609,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -15973,6 +15975,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/swagger-autogen": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.22.0.tgz",
+      "integrity": "sha512-MPdtwgx/RL3og0RjFVV9hPoQv3x+c3ZRhS0Vjp9k94DLV7iUgIuCg8H+uAT8oD5w48ATTRT1VjcOHlCGH62pdA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^7.4.1",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.7",
+        "json5": "^2.2.1"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.15.5.tgz",
+      "integrity": "sha512-V3eIa28lwB6gg7/wfNvAbjwJYmDXy1Jo1POjyTzlB6wPcHiGlRxq39TSjYGVjQrUSAzpv+a7nzp7mDxgNy57xA=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.0.tgz",
+      "integrity": "sha512-ZxpQFp1JR2RF8Ar++CyJzEDdvufa08ujNUJgMVTMWPi86CuQeVdBtvaeO/ysrz6dJAYXf9kbVNhWD7JWocwqsA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=4.11.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -20851,9 +20884,9 @@
       }
     },
     "acorn": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
     },
     "acorn-globals": {
@@ -22944,14 +22977,14 @@
       }
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -24194,13 +24227,10 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -24516,9 +24546,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -30096,6 +30126,31 @@
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
+      }
+    },
+    "swagger-autogen": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.22.0.tgz",
+      "integrity": "sha512-MPdtwgx/RL3og0RjFVV9hPoQv3x+c3ZRhS0Vjp9k94DLV7iUgIuCg8H+uAT8oD5w48ATTRT1VjcOHlCGH62pdA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.1",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.7",
+        "json5": "^2.2.1"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.15.5.tgz",
+      "integrity": "sha512-V3eIa28lwB6gg7/wfNvAbjwJYmDXy1Jo1POjyTzlB6wPcHiGlRxq39TSjYGVjQrUSAzpv+a7nzp7mDxgNy57xA=="
+    },
+    "swagger-ui-express": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.0.tgz",
+      "integrity": "sha512-ZxpQFp1JR2RF8Ar++CyJzEDdvufa08ujNUJgMVTMWPi86CuQeVdBtvaeO/ysrz6dJAYXf9kbVNhWD7JWocwqsA==",
+      "requires": {
+        "swagger-ui-dist": ">=4.11.0"
       }
     },
     "symbol-tree": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "start": "node src/app.js",
     "dev": "nodemon src/app.js",
     "prod": "NODE_ENV=prod nodemon src/app.js",
-    "test": "NODE_ENV=test jest tests/index.test.js"
+    "test": "NODE_ENV=test jest tests/index.test.js",
+    "swagger-autogen": "node ./swagger.js"
   },
   "devDependencies": {
     "@babel/core": "^7.10.2",
@@ -17,7 +18,8 @@
     "babel-jest": "^26.0.1",
     "jest": "^26.0.1",
     "nodemon": "^1.19.4",
-    "npm": "^6.12.0"
+    "npm": "^6.12.0",
+    "swagger-autogen": "^2.22.0"
   },
   "dependencies": {
     "angular-expressions": "^1.1.2",
@@ -41,6 +43,7 @@
     "otpauth": "^7.0.6",
     "qrcode": "^1.4.4",
     "socket.io": "^4.4.1",
+    "swagger-ui-express": "^4.6.0",
     "winston": "^2.3.1",
     "xml": "^1.0.1"
   }

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -13,6 +13,9 @@ var bodyParser = require('body-parser');
 var cookieParser = require('cookie-parser')
 var utils = require('./lib/utils');
 
+const swaggerUi = require('swagger-ui-express');
+const swaggerDocument = require('./config/swagger-output.json');
+
 // Get configuration
 var env = process.env.NODE_ENV || 'dev';
 var config = require('./config/config.json')[env];
@@ -110,6 +113,8 @@ require('./routes/vulnerability')(app);
 require('./routes/data')(app);
 require('./routes/image')(app);
 require('./routes/settings')(app);
+
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 app.get("*", function(req, res) {
     res.status(404).json({"status": "error", "data": "Route undefined"});

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -114,7 +114,9 @@ require('./routes/data')(app);
 require('./routes/image')(app);
 require('./routes/settings')(app);
 
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+if(config.apidoc) {
+  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+}
 
 app.get("*", function(req, res) {
     res.status(404).json({"status": "error", "data": "Route undefined"});

--- a/backend/src/config/config.json
+++ b/backend/src/config/config.json
@@ -6,7 +6,8 @@
             "name": "pwndoc",
             "server": "mongo-pwndoc-dev",
             "port": "27017"
-        }
+        },
+        "apidoc": true
     },
     "prod": {
         "port": 4242,
@@ -15,7 +16,8 @@
             "name": "pwndoc",
             "server": "mongo-pwndoc",
             "port": "27017"
-        }
+        },
+        "apidoc": false
     },
     "test": {
         "port": 6262,
@@ -24,6 +26,7 @@
             "name": "pwndoc",
             "server": "mongo-pwndoc-test",
             "port": "27017"
-        }
+        },
+        "apidoc": true
     }
 }

--- a/backend/src/config/swagger-output.json
+++ b/backend/src/config/swagger-output.json
@@ -1,0 +1,2117 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "PwndocNG API Documentation",
+    "description": "",
+    "version": "1.0.0"
+  },
+  "host": "/",
+  "basePath": "/",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/api/audits": {
+      "get": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "findingTitle",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "language": {
+                  "example": "any"
+                },
+                "auditType": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/audits/{auditId}": {
+      "delete": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      },
+      "get": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/audits/{auditId}/general": {
+      "get": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      },
+      "put": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "reviewers": {
+                  "example": "any"
+                },
+                "collaborators": {
+                  "example": "any"
+                },
+                "name": {
+                  "example": "any"
+                },
+                "location": {
+                  "example": "any"
+                },
+                "date": {
+                  "example": "any"
+                },
+                "date_start": {
+                  "example": "any"
+                },
+                "date_end": {
+                  "example": "any"
+                },
+                "client": {
+                  "example": "any"
+                },
+                "company": {
+                  "example": "any"
+                },
+                "language": {
+                  "example": "any"
+                },
+                "scope": {
+                  "example": "any"
+                },
+                "template": {
+                  "example": "any"
+                },
+                "customFields": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/audits/{auditId}/network": {
+      "get": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      },
+      "put": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "scope": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/audits/{auditId}/findings": {
+      "post": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "example": "any"
+                },
+                "vulnType": {
+                  "example": "any"
+                },
+                "description": {
+                  "example": "any"
+                },
+                "observation": {
+                  "example": "any"
+                },
+                "remediation": {
+                  "example": "any"
+                },
+                "remediationComplexity": {
+                  "example": "any"
+                },
+                "priority": {
+                  "example": "any"
+                },
+                "references": {
+                  "example": "any"
+                },
+                "cvssv3": {
+                  "example": "any"
+                },
+                "poc": {
+                  "example": "any"
+                },
+                "scope": {
+                  "example": "any"
+                },
+                "status": {
+                  "example": "any"
+                },
+                "category": {
+                  "example": "any"
+                },
+                "customFields": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/audits/{auditId}/findings/{findingId}": {
+      "get": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "findingId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      },
+      "put": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "findingId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "example": "any"
+                },
+                "vulnType": {
+                  "example": "any"
+                },
+                "description": {
+                  "example": "any"
+                },
+                "observation": {
+                  "example": "any"
+                },
+                "remediation": {
+                  "example": "any"
+                },
+                "remediationComplexity": {
+                  "example": "any"
+                },
+                "priority": {
+                  "example": "any"
+                },
+                "references": {
+                  "example": "any"
+                },
+                "cvssv3": {
+                  "example": "any"
+                },
+                "poc": {
+                  "example": "any"
+                },
+                "scope": {
+                  "example": "any"
+                },
+                "status": {
+                  "example": "any"
+                },
+                "category": {
+                  "example": "any"
+                },
+                "customFields": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "delete": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "findingId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/audits/{auditId}/sections/{sectionId}": {
+      "get": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "sectionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      },
+      "put": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "sectionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "customFields": {
+                  "example": "any"
+                },
+                "text": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/audits/{auditId}/generate": {
+      "get": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/audits/{auditId}/sortfindings": {
+      "put": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "sortFindings": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/audits/{auditId}/movefinding": {
+      "put": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "oldIndex": {
+                  "example": "any"
+                },
+                "newIndex": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/audits/{auditId}/toggleApproval": {
+      "put": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/audits/{auditId}/updateReadyForReview": {
+      "put": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "auditId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "state": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/clients": {
+      "get": {
+        "tags": [
+          "Client"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "Client"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "example": "any"
+                },
+                "lastname": {
+                  "example": "any"
+                },
+                "firstname": {
+                  "example": "any"
+                },
+                "phone": {
+                  "example": "any"
+                },
+                "cell": {
+                  "example": "any"
+                },
+                "title": {
+                  "example": "any"
+                },
+                "company": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/clients/{id}": {
+      "put": {
+        "tags": [
+          "Client"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "example": "any"
+                },
+                "lastname": {
+                  "example": "any"
+                },
+                "firstname": {
+                  "example": "any"
+                },
+                "phone": {
+                  "example": "any"
+                },
+                "cell": {
+                  "example": "any"
+                },
+                "title": {
+                  "example": "any"
+                },
+                "company": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "delete": {
+        "tags": [
+          "Client"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/companies": {
+      "get": {
+        "tags": [
+          "Company"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "Company"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "shortName": {
+                  "example": "any"
+                },
+                "logo": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/companies/{id}": {
+      "put": {
+        "tags": [
+          "Company"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "shortName": {
+                  "example": "any"
+                },
+                "logo": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "delete": {
+        "tags": [
+          "Company"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/data/roles": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/data/languages": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "locale": {
+                  "example": "any"
+                },
+                "language": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "put": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "locale": {
+                  "example": "any"
+                },
+                "req": {
+                  "example": "any"
+                },
+                "forEach(e": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/data/languages/{locale(*)}": {
+      "delete": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "locale(*)",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/data/audit-types": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "templates": {
+                  "example": "any"
+                },
+                "sections": {
+                  "example": "any"
+                },
+                "hidden": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "put": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "templates": {
+                  "example": "any"
+                },
+                "forEach(e": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/data/audit-types/{name(*)}": {
+      "delete": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "name(*)",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/data/vulnerability-types": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "locale": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "put": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "locale": {
+                  "example": "any"
+                },
+                "forEach(e": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/data/vulnerability-types/{name(*)}": {
+      "delete": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "name(*)",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/data/vulnerability-categories": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "sortValue": {
+                  "example": "any"
+                },
+                "sortOrder": {
+                  "example": "any"
+                },
+                "sortAuto": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "put": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "forEach(e": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/data/vulnerability-categories/{name(*)}": {
+      "delete": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "name(*)",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/data/sections": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "example": "any"
+                },
+                "name": {
+                  "example": "any"
+                },
+                "locale": {
+                  "example": "any"
+                },
+                "text": {
+                  "example": "any"
+                },
+                "icon": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "put": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "field": {
+                  "example": "any"
+                },
+                "forEach(e": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/data/sections/{field}/{locale(*)}": {
+      "delete": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "field",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "locale(*)",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/data/custom-fields": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "fieldType": {
+                  "example": "any"
+                },
+                "label": {
+                  "example": "any"
+                },
+                "display": {
+                  "example": "any"
+                },
+                "displaySub": {
+                  "example": "any"
+                },
+                "size": {
+                  "example": "any"
+                },
+                "offset": {
+                  "example": "any"
+                },
+                "required": {
+                  "example": "any"
+                },
+                "description": {
+                  "example": "any"
+                },
+                "text": {
+                  "example": "any"
+                },
+                "options": {
+                  "example": "any"
+                },
+                "position": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "put": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "example": "any"
+                },
+                "_id": {
+                  "example": "any"
+                },
+                "display": {
+                  "example": "any"
+                },
+                "fieldType": {
+                  "example": "any"
+                },
+                "forEach(e": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/data/custom-fields/{fieldId}": {
+      "delete": {
+        "tags": [
+          "Data"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/images/{imageId}": {
+      "get": {
+        "tags": [
+          "Image"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "imageId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      },
+      "delete": {
+        "tags": [
+          "Image"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "imageId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/images/": {
+      "post": {
+        "tags": [
+          "Image"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "example": "any"
+                },
+                "name": {
+                  "example": "any"
+                },
+                "auditId": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/images/download/{imageId}": {
+      "get": {
+        "tags": [
+          "Image"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "imageId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/settings": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "put": {
+        "tags": [
+          "Settings"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/settings/public": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/settings/revert": {
+      "put": {
+        "tags": [
+          "Settings"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/settings/export": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/templates": {
+      "get": {
+        "tags": [
+          "Templates"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "Templates"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "file": {
+                  "example": "any"
+                },
+                "ext": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/templates/{templateId}": {
+      "put": {
+        "tags": [
+          "Templates"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "file": {
+                  "example": "any"
+                },
+                "ext": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "delete": {
+        "tags": [
+          "Templates"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/templates/download/{templateId}": {
+      "get": {
+        "tags": [
+          "Templates"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/users/checktoken": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/users/refreshtoken": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "user-agent",
+            "in": "header",
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      },
+      "delete": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/users/token": {
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "user-agent",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "password": {
+                  "example": "any"
+                },
+                "username": {
+                  "example": "any"
+                },
+                "totpToken": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/users/init": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/users": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "username": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                },
+                "firstname": {
+                  "example": "any"
+                },
+                "lastname": {
+                  "example": "any"
+                },
+                "role": {
+                  "example": "any"
+                },
+                "email": {
+                  "example": "any"
+                },
+                "phone": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/users/reviewers": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/users/me": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "put": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "currentPassword": {
+                  "example": "any"
+                },
+                "newPassword": {
+                  "example": "any"
+                },
+                "confirmPassword": {
+                  "example": "any"
+                },
+                "username": {
+                  "example": "any"
+                },
+                "firstname": {
+                  "example": "any"
+                },
+                "lastname": {
+                  "example": "any"
+                },
+                "email": {
+                  "example": "any"
+                },
+                "phone": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/users/totp": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "totpToken": {
+                  "example": "any"
+                },
+                "totpSecret": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "delete": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "totpToken": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/users/{username}": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/users/{id}": {
+      "put": {
+        "tags": [
+          "User"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "password": {
+                  "example": "any"
+                },
+                "username": {
+                  "example": "any"
+                },
+                "firstname": {
+                  "example": "any"
+                },
+                "lastname": {
+                  "example": "any"
+                },
+                "email": {
+                  "example": "any"
+                },
+                "phone": {
+                  "example": "any"
+                },
+                "role": {
+                  "example": "any"
+                },
+                "totpEnabled": {
+                  "example": "any"
+                },
+                "enabled": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/vulnerabilities": {
+      "get": {
+        "tags": [
+          "Vulnerabilities"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tags": [
+          "Vulnerabilities"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "length": {
+                  "example": "any"
+                },
+                "details": {
+                  "example": "any"
+                },
+                "cvssv3": {
+                  "example": "any"
+                },
+                "priority": {
+                  "example": "any"
+                },
+                "remediationComplexity": {
+                  "example": "any"
+                },
+                "category": {
+                  "example": "any"
+                },
+                "status": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "delete": {
+        "tags": [
+          "Vulnerabilities"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/vulnerabilities/export": {
+      "get": {
+        "tags": [
+          "Vulnerabilities"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/vulnerabilities/{vulnerabilityId}": {
+      "put": {
+        "tags": [
+          "Vulnerabilities"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "vulnerabilityId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "details": {
+                  "example": "any"
+                },
+                "cvssv3": {
+                  "example": "any"
+                },
+                "priority": {
+                  "example": "any"
+                },
+                "remediationComplexity": {
+                  "example": "any"
+                },
+                "category": {
+                  "example": "any"
+                },
+                "status": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "delete": {
+        "tags": [
+          "Vulnerabilities"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "vulnerabilityId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/vulnerabilities/{locale}": {
+      "get": {
+        "tags": [
+          "Vulnerabilities"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "locale",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/vulnerabilities/finding/{locale}": {
+      "post": {
+        "tags": [
+          "Vulnerabilities"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "locale",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "example": "any"
+                },
+                "cvssv3": {
+                  "example": "any"
+                },
+                "priority": {
+                  "example": "any"
+                },
+                "remediationComplexity": {
+                  "example": "any"
+                },
+                "references": {
+                  "example": "any"
+                },
+                "vulnType": {
+                  "example": "any"
+                },
+                "description": {
+                  "example": "any"
+                },
+                "observation": {
+                  "example": "any"
+                },
+                "remediation": {
+                  "example": "any"
+                },
+                "category": {
+                  "example": "any"
+                },
+                "customFields": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/vulnerabilities/updates/{vulnId}": {
+      "get": {
+        "tags": [
+          "Vulnerabilities"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "vulnId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/api/vulnerabilities/merge/{vulnId}": {
+      "put": {
+        "tags": [
+          "Vulnerabilities"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "vulnId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "vulnId": {
+                  "example": "any"
+                },
+                "locale": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    }
+  }
+}

--- a/backend/src/routes/audit.js
+++ b/backend/src/routes/audit.js
@@ -12,6 +12,8 @@ module.exports = function(app, io) {
 
     // Get audits list of user (all for admin) with regex filter on findings
     app.get("/api/audits", acl.hasPermission('audits:read'), function(req, res) {
+        // #swagger.tags = ['Audit']
+
         var getUsersRoom = function(room) {
             return utils.getSockets(io, room).map(s => s.username)
         }
@@ -46,6 +48,8 @@ module.exports = function(app, io) {
 
     // Create audit with name, auditType, language provided
     app.post("/api/audits", acl.hasPermission('audits:create'), function(req, res) {
+        // #swagger.tags = ['Audit']
+
         if (!req.body.name || !req.body.language || !req.body.auditType) {
             Response.BadParameters(res, 'Missing some required parameters: name, language, auditType');
             return;
@@ -64,6 +68,8 @@ module.exports = function(app, io) {
 
     // Delete audit if creator or admin
     app.delete("/api/audits/:auditId", acl.hasPermission('audits:delete'), function(req, res) {
+        // #swagger.tags = ['Audit']
+
         Audit.delete(acl.isAllowed(req.decodedToken.role, 'audits:delete-all'), req.params.auditId, req.decodedToken.id)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -73,6 +79,8 @@ module.exports = function(app, io) {
 
     // Get Audit with ID
     app.get("/api/audits/:auditId", acl.hasPermission('audits:read'), function(req, res) {
+        // #swagger.tags = ['Audit']
+
         Audit.getAudit(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -80,6 +88,8 @@ module.exports = function(app, io) {
 
     // Get audit general information
     app.get("/api/audits/:auditId/general", acl.hasPermission('audits:read'), function(req, res) {
+        // #swagger.tags = ['Audit']
+
         Audit.getGeneral(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -87,6 +97,8 @@ module.exports = function(app, io) {
 
     // Update audit general information
     app.put("/api/audits/:auditId/general", acl.hasPermission('audits:update'), async function(req, res) {
+        // #swagger.tags = ['Audit']
+
         var update = {};
         
         var settings = await Settings.getAll();
@@ -186,6 +198,8 @@ module.exports = function(app, io) {
 
     // Get audit network information
     app.get("/api/audits/:auditId/network", acl.hasPermission('audits:read'), function(req, res) {
+        // #swagger.tags = ['Audit']
+
         Audit.getNetwork(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -193,6 +207,8 @@ module.exports = function(app, io) {
 
     // Update audit network information
     app.put("/api/audits/:auditId/network", acl.hasPermission('audits:update'), async function(req, res) {
+        // #swagger.tags = ['Audit']
+
         var settings = await Settings.getAll();
 
         var audit = await Audit.getAudit(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id);
@@ -213,6 +229,8 @@ module.exports = function(app, io) {
 
     // Add finding to audit
     app.post("/api/audits/:auditId/findings", acl.hasPermission('audits:update'), async function(req, res) {
+        // #swagger.tags = ['Audit']
+
         var settings = await Settings.getAll();
         var audit = await Audit.getAudit(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id);
         if (settings.reviews.enabled && audit.state !== "EDIT") {
@@ -257,6 +275,8 @@ module.exports = function(app, io) {
 
     // Get finding of audit
     app.get("/api/audits/:auditId/findings/:findingId", acl.hasPermission('audits:read'), function(req, res) {
+        // #swagger.tags = ['Audit']
+
         Audit.getFinding(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id, req.params.findingId)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -264,6 +284,8 @@ module.exports = function(app, io) {
 
     // Update finding of audit
     app.put("/api/audits/:auditId/findings/:findingId", acl.hasPermission('audits:update'), async function(req, res) {
+        // #swagger.tags = ['Audit']
+
         var settings = await Settings.getAll();
         var audit = await Audit.getAudit(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id);
         if (settings.reviews.enabled && audit.state !== "EDIT") {
@@ -302,6 +324,8 @@ module.exports = function(app, io) {
 
     // Delete finding of audit
     app.delete("/api/audits/:auditId/findings/:findingId", acl.hasPermission('audits:update'), async function(req, res) {
+        // #swagger.tags = ['Audit']
+
         var settings = await Settings.getAll();
         var audit = await Audit.getAudit(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id);
         if (settings.reviews.enabled && audit.state !== "EDIT") {
@@ -318,6 +342,8 @@ module.exports = function(app, io) {
 
     // Get section of audit
     app.get("/api/audits/:auditId/sections/:sectionId", acl.hasPermission('audits:read'), function(req, res) {
+        // #swagger.tags = ['Audit']
+
         Audit.getSection(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id, req.params.sectionId)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -325,6 +351,8 @@ module.exports = function(app, io) {
 
     // Update section of audit
     app.put("/api/audits/:auditId/sections/:sectionId", acl.hasPermission('audits:update'), async function(req, res) {
+        // #swagger.tags = ['Audit']
+
         var settings = await Settings.getAll();
         var audit = await Audit.getAudit(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id);
         if (settings.reviews.enabled && audit.state !== "EDIT") {
@@ -355,6 +383,8 @@ module.exports = function(app, io) {
 
     // Generate Report for specific audit
     app.get("/api/audits/:auditId/generate", acl.hasPermission('audits:read'), function(req, res){
+        // #swagger.tags = ['Audit']
+
         Audit.getAudit(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id)
         .then(async audit => {
             var settings = await Settings.getAll();
@@ -380,6 +410,8 @@ module.exports = function(app, io) {
 
     // Update sort options of an audit
     app.put("/api/audits/:auditId/sortfindings", acl.hasPermission('audits:update'), async function(req, res) {
+        // #swagger.tags = ['Audit']
+
         var settings = await Settings.getAll();
         var audit = await Audit.getAudit(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id);
         if (settings.reviews.enabled && audit.state !== "EDIT") {
@@ -401,6 +433,8 @@ module.exports = function(app, io) {
 
     // Update finding position (oldIndex -> newIndex)
     app.put("/api/audits/:auditId/movefinding", acl.hasPermission('audits:update'), async function(req, res) {
+        // #swagger.tags = ['Audit']
+
         var settings = await Settings.getAll();
         var audit = await Audit.getAudit(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.params.auditId, req.decodedToken.id);
         if (settings.reviews.enabled && audit.state !== "EDIT") {
@@ -431,6 +465,8 @@ module.exports = function(app, io) {
 
     // Give or remove a reviewer's approval to an audit
     app.put("/api/audits/:auditId/toggleApproval", acl.hasPermission('audits:review'), async function(req, res) {
+        // #swagger.tags = ['Audit']
+
         const settings = await Settings.getAll();
 
         if (!settings.reviews.enabled) {
@@ -484,6 +520,9 @@ module.exports = function(app, io) {
 
     // Sets the audit state to EDIT or REVIEW
     app.put("/api/audits/:auditId/updateReadyForReview", acl.hasPermission('audits:update'), async function(req, res) {
+        // #swagger.tags = ['Audit']
+
+
         const settings = await Settings.getAll();
 
         if (!settings.reviews.enabled) {

--- a/backend/src/routes/client.js
+++ b/backend/src/routes/client.js
@@ -6,6 +6,8 @@ module.exports = function(app) {
 
     // Get clients list
     app.get("/api/clients", acl.hasPermission('clients:read'), function(req, res) {
+        // #swagger.tags = ['Client']
+
         Client.getAll()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -13,6 +15,8 @@ module.exports = function(app) {
 
     // Create client
     app.post("/api/clients", acl.hasPermission('clients:create'), function(req, res) {
+        // #swagger.tags = ['Client']
+
         if (!req.body.email) {
             Response.BadParameters(res, 'Required parameters: email');
             return;
@@ -38,6 +42,8 @@ module.exports = function(app) {
 
     // Update client
     app.put("/api/clients/:id", acl.hasPermission('clients:update'), function(req, res) {
+        // #swagger.tags = ['Client']
+
         var client = {};
         // Optional parameters
         if (req.body.email) client.email = req.body.email;
@@ -56,6 +62,8 @@ module.exports = function(app) {
 
     // Delete client
     app.delete("/api/clients/:id", acl.hasPermission('clients:delete'), function(req, res) {
+        // #swagger.tags = ['Client']
+
         Client.delete(req.params.id)
         .then(msg => Response.Ok(res, 'Client deleted successfully'))
         .catch(err => Response.Internal(res, err))

--- a/backend/src/routes/company.js
+++ b/backend/src/routes/company.js
@@ -6,6 +6,8 @@ module.exports = function(app) {
 
     // Get companies list
     app.get("/api/companies", acl.hasPermission('companies:read'), function(req, res) {
+        // #swagger.tags = ['Company']
+
         Company.getAll()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -13,6 +15,8 @@ module.exports = function(app) {
 
     // Create company
     app.post("/api/companies", acl.hasPermission('companies:create'), function(req, res) {
+        // #swagger.tags = ['Company']
+
         if (!req.body.name) {
             Response.BadParameters(res, 'Required paramters: name');
             return;
@@ -33,6 +37,8 @@ module.exports = function(app) {
 
     // Update company
     app.put("/api/companies/:id", acl.hasPermission('companies:update'), function(req, res) {
+        // #swagger.tags = ['Company']
+
         var company = {};
         // Optional parameters
         if (req.body.name) company.name = req.body.name;
@@ -46,6 +52,8 @@ module.exports = function(app) {
 
     // Delete company
     app.delete("/api/companies/:id", acl.hasPermission('companies:delete'), function(req, res) {
+        // #swagger.tags = ['Company']
+
         Company.delete(req.params.id)
         .then(msg => Response.Ok(res, 'Company deleted successfully'))
         .catch(err => Response.Internal(res, err))

--- a/backend/src/routes/data.js
+++ b/backend/src/routes/data.js
@@ -18,6 +18,8 @@ module.exports = function(app) {
 
     // Get Roles list
     app.get("/api/data/roles", acl.hasPermission('roles:read'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         try {
             var result = Object.keys(acl.roles)
             Response.Ok(res, result)
@@ -31,6 +33,8 @@ module.exports = function(app) {
 
     // Get languages list
     app.get("/api/data/languages", acl.hasPermission('languages:read'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         Language.getAll()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -38,6 +42,8 @@ module.exports = function(app) {
 
     // Create language
     app.post("/api/data/languages", acl.hasPermission('languages:create'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         if (!req.body.locale || !req.body.language) {
             Response.BadParameters(res, 'Missing required parameters: locale, language');
             return;
@@ -58,6 +64,8 @@ module.exports = function(app) {
     
     // Delete Language
     app.delete("/api/data/languages/:locale(*)", acl.hasPermission('languages:delete'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         Language.delete(req.params.locale)
         .then(msg => {
             Response.Ok(res, 'Language deleted successfully')
@@ -67,6 +75,8 @@ module.exports = function(app) {
 
     // Update Languages
     app.put("/api/data/languages", acl.hasPermission('languages:update'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         for (var i=0; i<req.body.length; i++) {
             var language = req.body[i]
             if (!language.locale || !language.language) {
@@ -93,6 +103,8 @@ module.exports = function(app) {
 
     // Get audit types list
     app.get("/api/data/audit-types", acl.hasPermission('audit-types:read'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         AuditType.getAll()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -100,6 +112,8 @@ module.exports = function(app) {
 
     // Create audit type
     app.post("/api/data/audit-types", acl.hasPermission('audit-types:create'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         if (!req.body.name || !req.body.templates) {
             Response.BadParameters(res, 'Missing required parameters: name, templates');
             return;
@@ -125,6 +139,8 @@ module.exports = function(app) {
     
     // Delete audit type
     app.delete("/api/data/audit-types/:name(*)", acl.hasPermission('audit-types:delete'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         AuditType.delete(req.params.name)
         .then(msg => {
             Response.Ok(res, 'Audit type deleted successfully')
@@ -134,6 +150,8 @@ module.exports = function(app) {
 
     // Update Audit Types
     app.put("/api/data/audit-types", acl.hasPermission('audit-types:update'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         for (var i=0; i<req.body.length; i++) {
             var auditType = req.body[i]
             if (!auditType.name || !auditType.templates) {
@@ -160,13 +178,17 @@ module.exports = function(app) {
 
      // Get vulnerability types list
      app.get("/api/data/vulnerability-types", acl.hasPermission('vulnerability-types:read'), function(req, res) {
-        VulnerabilityType.getAll()
+         // #swagger.tags = ['Data']
+
+         VulnerabilityType.getAll()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
     });
 
     // Create vulnerability type
     app.post("/api/data/vulnerability-types", acl.hasPermission('vulnerability-types:create'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         if (!req.body.name || !req.body.locale) {
             Response.BadParameters(res, 'Missing required parameters: name, locale');
             return;
@@ -186,6 +208,8 @@ module.exports = function(app) {
     
     // Delete vulnerability type
     app.delete("/api/data/vulnerability-types/:name(*)", acl.hasPermission('vulnerability-types:delete'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         VulnerabilityType.delete(req.params.name)
         .then(msg => {
             Response.Ok(res, 'Vulnerability type deleted successfully')
@@ -195,6 +219,8 @@ module.exports = function(app) {
 
     // Update Vulnerability Types
     app.put("/api/data/vulnerability-types", acl.hasPermission('vulnerability-types:update'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         for (var i=0; i<req.body.length; i++) {
             var vulnType = req.body[i]
             if (!vulnType.name || !vulnType.locale) {
@@ -221,13 +247,17 @@ module.exports = function(app) {
 
      // Get vulnerability category list
      app.get("/api/data/vulnerability-categories", acl.hasPermission('vulnerability-categories:read'), function(req, res) {
-        VulnerabilityCategory.getAll()
+         // #swagger.tags = ['Data']
+
+         VulnerabilityCategory.getAll()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
     });
 
     // Create vulnerability category
     app.post("/api/data/vulnerability-categories", acl.hasPermission('vulnerability-categories:create'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         if (!req.body.name) {
             Response.BadParameters(res, 'Missing required parameters: name');
             return;
@@ -253,6 +283,8 @@ module.exports = function(app) {
 
     // Update Vulnerability Category
     app.put("/api/data/vulnerability-categories", acl.hasPermission('vulnerability-categories:update'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         for (var i=0; i<req.body.length; i++) {
             var vulnCat = req.body[i]
             if (!vulnCat.name) {
@@ -285,6 +317,8 @@ module.exports = function(app) {
     
     // Delete vulnerability category
     app.delete("/api/data/vulnerability-categories/:name(*)", acl.hasPermission('vulnerability-categories:delete'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         VulnerabilityCategory.delete(req.params.name)
         .then(msg => {
             Response.Ok(res, 'Vulnerability category deleted successfully')
@@ -296,6 +330,8 @@ module.exports = function(app) {
 
     // Get sections list
     app.get("/api/data/sections", acl.hasPermission('sections:read'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         CustomSection.getAll()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -303,6 +339,8 @@ module.exports = function(app) {
 
     // Create section
     app.post("/api/data/sections", acl.hasPermission('sections:create'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         if (!req.body.field || !req.body.name) {
             Response.BadParameters(res, 'Missing required parameters: field, name');
             return;
@@ -327,6 +365,8 @@ module.exports = function(app) {
     
     // Delete section
     app.delete("/api/data/sections/:field/:locale(*)", acl.hasPermission('sections:delete'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         CustomSection.delete(req.params.field, req.params.locale)
         .then(msg => {
             Response.Ok(res, 'Section deleted successfully')
@@ -336,7 +376,9 @@ module.exports = function(app) {
 
      // Update sections
      app.put("/api/data/sections", acl.hasPermission('sections:update'), function(req, res) {
-        for (var i=0; i<req.body.length; i++) {
+         // #swagger.tags = ['Data']
+
+         for (var i=0; i<req.body.length; i++) {
             var section = req.body[i]
             if (!section.name || !section.field) {
                 Response.BadParameters(res, 'Missing required parameters: name, field')
@@ -362,6 +404,8 @@ module.exports = function(app) {
 
     // Get custom fields
     app.get("/api/data/custom-fields", acl.hasPermission('custom-fields:read'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         CustomField.getAll()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -369,6 +413,8 @@ module.exports = function(app) {
 
     // Create custom field
     app.post("/api/data/custom-fields", acl.hasPermission('custom-fields:create'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         if ((!req.body.fieldType || !req.body.label || !req.body.display) && req.body.fieldType !== 'space') {
             Response.BadParameters(res, 'Missing required parameters: fieldType, label, display')
             return
@@ -398,7 +444,9 @@ module.exports = function(app) {
 
      // Update custom fields
      app.put("/api/data/custom-fields", acl.hasPermission('custom-fields:update'), function(req, res) {
-        for (var i=0; i<req.body.length; i++) {
+         // #swagger.tags = ['Data']
+
+         for (var i=0; i<req.body.length; i++) {
             var customField = req.body[i]
             if ((!customField.label || !customField._id || !customField.display) && customField.fieldType !== 'space') {
                 Response.BadParameters(res, 'Missing required parameters: _id, label, display')
@@ -430,6 +478,8 @@ module.exports = function(app) {
 
     // Delete custom field
     app.delete("/api/data/custom-fields/:fieldId", acl.hasPermission('custom-fields:delete'), function(req, res) {
+        // #swagger.tags = ['Data']
+
         CustomField.delete(req.params.fieldId)
         .then(msg => {
             Response.Ok(res, msg)

--- a/backend/src/routes/image.js
+++ b/backend/src/routes/image.js
@@ -6,6 +6,8 @@ module.exports = function(app) {
 
     // Get image
     app.get("/api/images/:imageId", acl.hasPermission('images:read'), function(req, res) {
+        // #swagger.tags = ['Image']
+
         Image.getOne(req.params.imageId)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -13,6 +15,8 @@ module.exports = function(app) {
 
     // Create image
     app.post("/api/images/", acl.hasPermission('images:create'), function(req, res) {
+        // #swagger.tags = ['Image']
+
         if (!req.body.value) {
             Response.BadParameters(res, 'Missing required parameters: value')
             return
@@ -39,6 +43,8 @@ module.exports = function(app) {
 
     // Delete image
     app.delete("/api/images/:imageId", acl.hasPermission('images:delete'), function(req, res) {
+        // #swagger.tags = ['Image']
+
         Image.delete(req.params.imageId)
         .then(data => {
             Response.Ok(res, 'Image deleted successfully')
@@ -50,6 +56,8 @@ module.exports = function(app) {
 
     // Download image file
     app.get("/api/images/download/:imageId", acl.hasPermission('images:read'), function(req, res) {
+        // #swagger.tags = ['Image']
+
         Image.getOne(req.params.imageId)
         .then(data => {
             var imgBase64 = data.value.split(",")[1]

--- a/backend/src/routes/settings.js
+++ b/backend/src/routes/settings.js
@@ -4,30 +4,40 @@ module.exports = function(app) {
     var Settings = require('mongoose').model('Settings');
     
     app.get("/api/settings", acl.hasPermission('settings:read'), function(req, res) {
+        // #swagger.tags = ['Settings']
+
         Settings.getAll()
         .then(settings => Response.Ok(res, settings))
         .catch(err => Response.Internal(res, err));
     });
 
     app.get("/api/settings/public", acl.hasPermission('settings:read-public'), function(req, res) {
+        // #swagger.tags = ['Settings']
+
         Settings.getPublic()
         .then(settings => Response.Ok(res, settings))
         .catch(err => Response.Internal(res, err));
     });
 
     app.put("/api/settings", acl.hasPermission('settings:update'), function(req, res) {
+        // #swagger.tags = ['Settings']
+
         Settings.update(req.body)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err));
     });
 
     app.put("/api/settings/revert", acl.hasPermission('settings:update'), function(req, res) {
+        // #swagger.tags = ['Settings']
+
         Settings.restoreDefaults()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err));
     });
 
     app.get("/api/settings/export", acl.hasPermission("settings:read"), function(req, res) {
+        // #swagger.tags = ['Settings']
+
         Settings.getAll()
         .then(settings => Response.SendFile(res, "app-settings.json", settings))
         .catch(err => Response.Internal(res, err))

--- a/backend/src/routes/template.js
+++ b/backend/src/routes/template.js
@@ -8,6 +8,8 @@ module.exports = function(app) {
 
     // Get templates list
     app.get("/api/templates", acl.hasPermission('templates:read'), function(req, res) {
+        // #swagger.tags = ['Templates']
+
         Template.getAll()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -15,6 +17,8 @@ module.exports = function(app) {
 
     // Create template
     app.post("/api/templates", acl.hasPermission('templates:create'), function(req, res) {
+        // #swagger.tags = ['Templates']
+
         if (!req.body.name || !req.body.file || !req.body.ext) {
             Response.BadParameters(res, 'Missing required parameters: name, ext, file');
             return;
@@ -41,6 +45,8 @@ module.exports = function(app) {
 
     // Update template
     app.put("/api/templates/:templateId", acl.hasPermission('templates:update'), function(req, res) {
+        // #swagger.tags = ['Templates']
+
         if (req.body.name && !utils.validFilename(req.body.name)) {
             Response.BadParameters(res, 'Bad name format');
             return;
@@ -81,6 +87,8 @@ module.exports = function(app) {
 
     // Delete template
     app.delete("/api/templates/:templateId", acl.hasPermission('templates:delete'), function(req, res) {
+        // #swagger.tags = ['Templates']
+
         Template.delete(req.params.templateId)
         .then(data => {
             fs.unlinkSync(`${__basedir}/../report-templates/${data.name}.${data.ext || 'docx'}`)
@@ -97,7 +105,9 @@ module.exports = function(app) {
 
      // Download template file
      app.get("/api/templates/download/:templateId", acl.hasPermission('templates:read'), function(req, res) {
-        Template.getOne(req.params.templateId)
+         // #swagger.tags = ['Templates']
+
+         Template.getOne(req.params.templateId)
         .then(data => {
             var file = `${__basedir}/../report-templates/${data.name}.${data.ext || 'docx'}`
             res.download(file, `${data.name}.${data.ext}`)

--- a/backend/src/routes/user.js
+++ b/backend/src/routes/user.js
@@ -10,11 +10,15 @@ module.exports = function(app) {
 	
     // Check token validity
     app.get("/api/users/checktoken", acl.hasPermission('validtoken'), function(req, res) {
+        // #swagger.tags = ['User']
+
         Response.Ok(res, req.cookies['token']);
     });
 
     // Refresh token
     app.get("/api/users/refreshtoken", function(req, res) {
+        // #swagger.tags = ['User']
+
         var userAgent = req.headers['user-agent']
         var token = req.cookies['refreshToken']
         
@@ -35,6 +39,8 @@ module.exports = function(app) {
 
     // Remove token cookie
     app.delete("/api/users/refreshtoken", function(req, res) {
+        // #swagger.tags = ['User']
+
         var token = req.cookies['refreshToken']
         try {
             var decoded = jwt.verify(token, jwtRefreshSecret)
@@ -59,6 +65,8 @@ module.exports = function(app) {
 
     // Authenticate user -> return JWT token
     app.post("/api/users/token", function(req, res) {
+        // #swagger.tags = ['User']
+
         if (!req.body.password || !req.body.username) {
             Response.BadParameters(res, 'Required parameters: username, password');
             return;
@@ -91,6 +99,8 @@ module.exports = function(app) {
 
     // Check if there are any existing users for creating first user
     app.get("/api/users/init", function(req, res) {
+        // #swagger.tags = ['User']
+
         User.getAll()
         .then(msg => Response.Ok(res, msg.length === 0))
         .catch(err => Response.Internal(res, err))
@@ -98,6 +108,8 @@ module.exports = function(app) {
 
     // Get all users
     app.get("/api/users", acl.hasPermission('users:read'), function(req, res) {
+        // #swagger.tags = ['User']
+
         User.getAll()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -105,6 +117,8 @@ module.exports = function(app) {
 
     // Get all reviewers
     app.get("/api/users/reviewers", acl.hasPermission('users:read'), function(req, res) {
+        // #swagger.tags = ['User']
+
         User.getAll()
         .then((users) => {
             var reviewers = [];
@@ -120,6 +134,8 @@ module.exports = function(app) {
 
     // Get user self
     app.get("/api/users/me", acl.hasPermission('validtoken'), function(req, res) {
+        // #swagger.tags = ['User']
+
         User.getByUsername(req.decodedToken.username)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -127,6 +143,8 @@ module.exports = function(app) {
 
     //get TOTP Qrcode URL
     app.get("/api/users/totp", acl.hasPermission('validtoken'), function(req, res) {
+        // #swagger.tags = ['User']
+
         User.getTotpQrcode(req.decodedToken.username)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -134,6 +152,8 @@ module.exports = function(app) {
 
     //setup TOTP
     app.post("/api/users/totp", acl.hasPermission('validtoken'), function(req, res) {
+        // #swagger.tags = ['User']
+
         if (!req.body.totpToken || !req.body.totpSecret) {
             Response.BadParameters(res, 'Missing some required parameters');
             return;
@@ -146,6 +166,8 @@ module.exports = function(app) {
 
     //cancel TOTP
     app.delete("/api/users/totp", acl.hasPermission('validtoken'), function(req, res) {
+        // #swagger.tags = ['User']
+
         if (!req.body.totpToken) {
             Response.BadParameters(res, 'Missing some required parameters');
             return;
@@ -158,6 +180,8 @@ module.exports = function(app) {
 
     // Get user by username
     app.get("/api/users/:username", acl.hasPermission('users:read'), function(req, res) {
+        // #swagger.tags = ['User']
+
         User.getByUsername(req.params.username)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -165,6 +189,8 @@ module.exports = function(app) {
 
     // Create user
     app.post("/api/users", acl.hasPermission('users:create'), function(req, res) {
+        // #swagger.tags = ['User']
+
         if (!req.body.username || !req.body.password || !req.body.firstname || !req.body.lastname) {
             Response.BadParameters(res, 'Missing some required parameters');
             return;
@@ -193,6 +219,8 @@ module.exports = function(app) {
 
     // Create First User
     app.post("/api/users/init", function(req, res) {
+        // #swagger.tags = ['User']
+
         if (!req.body.username || !req.body.password || !req.body.firstname || !req.body.lastname) {
             Response.BadParameters(res, 'Missing some required parameters');
             return;
@@ -236,6 +264,8 @@ module.exports = function(app) {
 
     // Update my profile
     app.put("/api/users/me", acl.hasPermission('validtoken'), function(req, res) {
+        // #swagger.tags = ['User']
+
         if (!req.body.currentPassword ||
             (req.body.newPassword && !req.body.confirmPassword) ||
             (req.body.confirmPassword && !req.body.newPassword)) {
@@ -273,6 +303,8 @@ module.exports = function(app) {
 
     // Update any user (admin only)
     app.put("/api/users/:id", acl.hasPermission('users:update'), function(req, res) {
+        // #swagger.tags = ['User']
+
         if (req.body.password && !passwordpolicy.strongPassword(req.body.password)){
             Response.BadParameters(res, 'New Password does not match the password policy');
             return;

--- a/backend/src/routes/vulnerability.js
+++ b/backend/src/routes/vulnerability.js
@@ -9,6 +9,8 @@ module.exports = function(app) {
 
     // Get vulnerabilities list
     app.get("/api/vulnerabilities", acl.hasPermission('vulnerabilities:read'), function(req, res) {
+        // #swagger.tags = ['Vulnerabilities']
+
         Vulnerability.getAll()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -16,6 +18,8 @@ module.exports = function(app) {
 
     // Get vulnerabilities for export
     app.get("/api/vulnerabilities/export", acl.hasPermission('vulnerabilities:read'), function(req, res) {
+        // #swagger.tags = ['Vulnerabilities']
+
         Vulnerability.export()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -23,6 +27,8 @@ module.exports = function(app) {
 
     // Create vulnerabilities (array of vulnerabilities)
     app.post("/api/vulnerabilities", acl.hasPermission('vulnerabilities:create'), function(req, res) {
+        // #swagger.tags = ['Vulnerabilities']
+
         for (var i=0; i< req.body.length;i++) {
             var vuln = req.body[i]
             if (!vuln.details) {
@@ -75,6 +81,8 @@ module.exports = function(app) {
 
     // Update vulnerability
     app.put("/api/vulnerabilities/:vulnerabilityId", acl.hasPermission('vulnerabilities:update'), function(req, res) {
+        // #swagger.tags = ['Vulnerabilities']
+
         if (!req.body.details) {
             Response.BadParameters(res, 'Required parameters: details.locale, details.title');
             return;
@@ -118,6 +126,8 @@ module.exports = function(app) {
 
     // Delete vulnerability
     app.delete("/api/vulnerabilities/:vulnerabilityId", acl.hasPermission('vulnerabilities:delete'), function(req, res) {
+        // #swagger.tags = ['Vulnerabilities']
+
         Vulnerability.delete(req.params.vulnerabilityId)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -125,6 +135,8 @@ module.exports = function(app) {
 
     // Delete all vulnerabilities
     app.delete("/api/vulnerabilities", acl.hasPermission('vulnerabilities:delete-all'), function(req, res) {
+        // #swagger.tags = ['Vulnerabilities']
+
         Vulnerability.deleteAll()
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -132,6 +144,8 @@ module.exports = function(app) {
 
     // Get vulnerabilities list by language
     app.get("/api/vulnerabilities/:locale", acl.hasPermission('vulnerabilities:read'), function(req, res) {
+        // #swagger.tags = ['Vulnerabilities']
+
         Vulnerability.getAllByLanguage(req.params.locale)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -139,6 +153,8 @@ module.exports = function(app) {
 
     // Create or Update vulnerability from finding for validation
     app.post("/api/vulnerabilities/finding/:locale", acl.hasPermission('vulnerability-updates:create'), function(req, res) {
+        // #swagger.tags = ['Vulnerabilities']
+
         if (!req.body.title) {
             Response.BadParameters(res, 'Required parameters: title');
             return;
@@ -173,6 +189,8 @@ module.exports = function(app) {
 
     // Get vulnerability updates form vuln id
     app.get("/api/vulnerabilities/updates/:vulnId", acl.hasPermission('vulnerabilities:update'), function(req, res) {
+        // #swagger.tags = ['Vulnerabilities']
+
         VulnerabilityUpdate.getAllByVuln(req.params.vulnId)
         .then(msg => Response.Ok(res, msg))
         .catch(err => Response.Internal(res, err))
@@ -180,6 +198,8 @@ module.exports = function(app) {
 
     // Merge vulnerability with locale part of another one
     app.put("/api/vulnerabilities/merge/:vulnId", acl.hasPermission('vulnerabilities:update'), function(req, res) {
+        // #swagger.tags = ['Vulnerabilities']
+
         if (!req.body.vulnId || !req.body.locale) {
             Response.BadParameters(res, 'Required parameters: vulnId, locale');
             return;

--- a/backend/swagger.js
+++ b/backend/swagger.js
@@ -1,0 +1,29 @@
+const swaggerAutogen = require('swagger-autogen')();
+
+const doc = {
+    info: {
+        title: 'PwndocNG API Documentation',
+        description: '',
+    },
+    host: '/',
+    schemes: ['http'],
+};
+
+const outputFile = './src/config/swagger-output.json';
+const endpointsFiles = [
+    './src/routes/audit.js',
+    './src/routes/client.js',
+    './src/routes/company.js',
+    './src/routes/data.js',
+    './src/routes/image.js',
+    './src/routes/settings.js',
+    './src/routes/template.js',
+    './src/routes/user.js',
+    './src/routes/vulnerability.js'
+];
+
+/* NOTE: if you use the express Router, you must pass in the
+   'endpointsFiles' only the root file where the route starts,
+   such as index.js, app.js, routes.js, ... */
+
+swaggerAutogen(outputFile, endpointsFiles, doc);


### PR DESCRIPTION
Generates and exposes an endpoint at /api-docs which serves a swaggerui with basic API docs.

![image](https://user-images.githubusercontent.com/636856/215144980-7b3bfad8-1e76-4612-92ff-ab3b1fd8f333.png)
