### PR TITLE
feature: add standard toolbar to affected assets section

### DIFF
--- a/frontend/src/pages/audits/edit/findings/edit/edit.html
+++ b/frontend/src/pages/audits/edit/findings/edit/edit.html
@@ -99,7 +99,7 @@
                 <q-card-section>
                     <q-field borderless>
                         <template v-slot="control">
-                            <basic-editor v-model="finding.scope" :toolbar="['format', 'marks', 'list']" :editable="frontEndAuditState === AUDIT_VIEW_STATE.EDIT"/>
+                            <basic-editor v-model="finding.scope" :editable="frontEndAuditState === AUDIT_VIEW_STATE.EDIT"/>
                         </template>
                     </q-field>
                 </q-card-section>


### PR DESCRIPTION
The affected assets within the vulnerability edit did not have the full toolbar, this change adds the full toolbar so you can have tables within that section.

![image](https://user-images.githubusercontent.com/636856/216193802-d7d1430c-5cf4-4583-be86-6b9ffb432730.png)
