### PR TITLE
docker update mongo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   mongodb:
-    image: mongo:4.2.15
+    image: mongo:4.2.24
     container_name: mongo-pwndoc
     volumes:
       - mongo-data:/data/db


### PR DESCRIPTION
The mongo image could propably be update safely to [4.2.24](https://hub.docker.com/layers/library/mongo/4.2.24/images/sha256-ea9fd9d4d4988bf2e8a68420b9ecf4da6e81ee8e29af084fcd4161aa128737a8?context=explore) and probably to [4.4.19](https://hub.docker.com/layers/library/mongo/4.4.19/images/sha256-a49ab711907c8a06f3a6d28c254eda2ea2afc6894cd0004b11daa277631f3b98?context=explore) too.

Of course [6.0.4](https://hub.docker.com/layers/library/mongo/6.0.4/images/sha256-3c8dd1b08f8a2ec0338902affd432b40130e5acf49d6e3a1ca05ff5168100059?context=explore) and [5.0.15](https://hub.docker.com/layers/library/mongo/5.0.15/images/sha256-b6594de6eba584a372b13c9e09af43a3d4da1d96299c8f45a6951992ca6d477b?context=explore) would probably break.