### PR TITLE
docker node image version

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:18.15.0-alpine3.16
 
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
It's better to pin a specific version and update it regularly rather than something generic like `lts` that will probably break when the next node LTS version will be released.

If validated I'll reflect that to all other docker files.