### PR TITLE
Fix custom sections always detected a modified

### DIFF
--- a/frontend/src/pages/audits/edit/sections/sections.js
+++ b/frontend/src/pages/audits/edit/sections/sections.js
@@ -101,9 +101,9 @@ export default {
             })
             .then((data) => {
                 this.section = data.data.datas;
+	        this.sectionOrig = this.$_.cloneDeep(this.section);
                 this.$nextTick(() => {
                     Utils.syncEditors(this.$refs)
-                    this.sectionOrig = this.$_.cloneDeep(this.section);                
                 })
             })
             .catch((err) => {


### PR DESCRIPTION
Currently, simply loading a custom section then attempting to leave the page will result in a an unsaved changes alert.

Testing:

- Create an audit with custom sections. 
- Open the custom section on the audit.
- Navigate away from the custom section.
  - [ ] You should not get a unsaved changes modal.
- Navigate back to the custom section.
- Modify the contents.
- Navigate away from the custom section.
  - [ ] You should get a modal warning you about unsaved changes.
- Save the custom section.
- Navigate away from the custom section.
  - [ ] You should not get a unsaved changes modal.