### PR TITLE
Add "Last Updated" column to vulnerabilities

### DIFF
--- a/backend/src/models/vulnerability.js
+++ b/backend/src/models/vulnerability.js
@@ -27,8 +27,8 @@ var VulnerabilitySchema = new Schema({
     details:                [VulnerabilityDetails],
     status:                 {type: Number, enum: [0,1,2], default: 1}, // 0: validated, 1: created, 2: updated,
     category:               String,
-    creator:                {type: Schema.Types.ObjectId, ref: 'User'}
-
+    creator:                {type: Schema.Types.ObjectId, ref: 'User'},
+    updatedAt:              String
 
 }, {timestamps: true});
 

--- a/frontend/src/i18n/de-DE/index.js
+++ b/frontend/src/i18n/de-DE/index.js
@@ -359,6 +359,7 @@ export default {
     details: 'Details',
     completed: 'Vollständig',
     type: 'Type',
+    lastUpdated: 'Zuletzt Aktualisiert',
     description: 'Beschreibung',
     observation: 'Beobachtung',
     references: 'Referenzen (eine pro Zeile)',

--- a/frontend/src/i18n/en-US/index.js
+++ b/frontend/src/i18n/en-US/index.js
@@ -36,7 +36,6 @@ export default {
         usersConnected: 'Users on the Audit:',
         editAudit: 'Edit Audit',
         downloadReport: 'Download Report',
-        insertId: 'Add vulnerabilities ID',
         deleteAudit: 'Delete Audit',
         topButtonSection: {
             submitReview: 'Mark audit as ready for review',

--- a/frontend/src/i18n/en-US/index.js
+++ b/frontend/src/i18n/en-US/index.js
@@ -36,6 +36,8 @@ export default {
         usersConnected: 'Users on the Audit:',
         editAudit: 'Edit Audit',
         downloadReport: 'Download Report',
+        downloadReportCsv: 'Download Report (CSV)',
+        insertId: 'Add vulnerabilities ID',
         deleteAudit: 'Delete Audit',
         topButtonSection: {
             submitReview: 'Mark audit as ready for review',
@@ -359,6 +361,7 @@ export default {
     details: 'Details',
     completed: 'Completed',
     type: 'Type',
+    lastUpdated: 'Last Updated',
     description: 'Description',
     observation: 'Observation',
     references: 'References (One per line)',

--- a/frontend/src/i18n/en-US/index.js
+++ b/frontend/src/i18n/en-US/index.js
@@ -36,7 +36,6 @@ export default {
         usersConnected: 'Users on the Audit:',
         editAudit: 'Edit Audit',
         downloadReport: 'Download Report',
-        downloadReportCsv: 'Download Report (CSV)',
         insertId: 'Add vulnerabilities ID',
         deleteAudit: 'Delete Audit',
         topButtonSection: {

--- a/frontend/src/i18n/fr-FR/index.js
+++ b/frontend/src/i18n/fr-FR/index.js
@@ -242,6 +242,7 @@ export default {
     details: 'Détails',
     completed: 'Completé',
     type: 'Type',
+    lastUpdated: 'Last Updated',
     description: 'Description',
     observation: 'Observation',
     references: 'Références (Une par ligne)',

--- a/frontend/src/i18n/zh-CN/index.js
+++ b/frontend/src/i18n/zh-CN/index.js
@@ -352,6 +352,7 @@ export default {
     details: '细节',
     completed: '已完成',
     type: '类型',
+    lastUpdated: '最后更新',
     description: '说明',
     observation: '观测',
     references: '参考资料（每条1行）',

--- a/frontend/src/pages/vulnerabilities/vulnerabilities.html
+++ b/frontend/src/pages/vulnerabilities/vulnerabilities.html
@@ -68,7 +68,7 @@
 
             <template v-slot:top-row="props">
                 <q-tr>
-                    <q-td style="width: 60%">
+                    <q-td style="width: 55%">
                         <q-input 
                         dense
                         :label="$t('search')"
@@ -78,7 +78,7 @@
                         outlined
                         />
                     </q-td>
-                    <q-td style="width: 20%">
+                    <q-td style="width: 15%">
                         <q-select 
                         dense
                         :label="$t('search')"
@@ -89,7 +89,7 @@
                         outlined
                         />
                     </q-td>
-                    <q-td style="width: 20%">
+                    <q-td style="width: 15%">
                         <q-select 
                         dense
                         :label="$t('search')"
@@ -99,6 +99,15 @@
                         options-sanitize
                         outlined
                         />
+                    </q-td>
+                    <q-td style="width: 15%">
+                        <q-input
+                        dense
+                        :label="$t('search')"
+                        v-model="search.updatedAt"
+                        outlined
+                        mask="##-##-####"
+                        >
                     </q-td>
                     <q-td></q-td>
                 </q-tr>
@@ -114,6 +123,9 @@
                     </q-td>
                     <q-td key="type" :props="props">
                         {{getDtType(props.row)}}
+                    </q-td>
+                    <q-td key="updatedAt" :props="props">
+                        {{getDtUpdatedAt(props.row)}}
                     </q-td>
                     <q-td key="action" :props="props" style="width:1px">
                         <q-btn v-if="UserService.isAllowed('vulnerabilities:update')" size="sm" flat color="primary" icon="fa fa-edit" @click="clone(props.row); (props.row.status === 2)?$refs.updatesModal.show():$refs.editModal.show()">


### PR DESCRIPTION
I saw the #285 and for me is a nice feature.

So i wrote/edited few lines in:
- `/frontend/src/pages/vulnerabilities/vulnerabilities.html`
  - New input (with mask), reduced by 5% other columns to gain space, arrows for sorting
- `/frontend/src/pages/vulnerabilities/vulnerabilities.js` 
  - Table headers, functions and logics
- `/backend/src/models/vulnerability.js`
  - Property "updatedAt"

And ofc the tooltip traslation (google translate) in:
- `/frontend/src/i18n/de-DE/index.js`
- `/frontend/src/i18n/en-US/index.js`
- `/frontend/src/i18n/fr-FR/index.js`
- `/frontend/src/i18n/zh-CN/index.js`

Maybe adding "updatedAt" directly to `VulnerabilitySchema` and not to `VulnerabilityDetails` isn't the smartest option but i'm unable to figure out another way.

These are my modifications, lmk!