### PR TITLE
Auto-Increamental VULN-ID based on order of Findings

### DIFF
--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -24,6 +24,11 @@ async function generateDoc(audit) {
     translate.setLocale(audit.language)
     $t = translate.translate
 
+    // set the identifier of each vulnerability to the index of the array
+    audit.findings.forEach((finding, index) => {
+        finding.identifier = index + 1
+    })
+
     var settings = await Settings.getAll();
     var preppedAudit = await prepAuditData(audit, settings)
 


### PR DESCRIPTION
Based on the issue at: https://github.com/pwndoc-ng/pwndoc-ng/issues/278, there's an enhancement I'd like to propose. Currently, to include the index of a finding in the report, you need to use `{identifier}` tag. However, this `identifier` is tied to when the vulnerability was added to the audit, which means it can be changed. Consequently, assigning specific indexes like 1, 2, and so on becomes challenging since the identifier determines the `index`.

To address this, I made a quick modification to `report-generator.js` so that the identifier is based on the index of the finding within the audit's array. This way, when the findings are sorted within the audit, the identifier adjusts accordingly, providing a more customizable and efficient indexing solution for vulnerabilities.

##
![image](https://github.com/pwndoc-ng/pwndoc-ng/assets/63105226/0bd85855-b245-4641-87e1-53199f0006cf)
Just use the Sorting that PwnDoc give you and VOILA
