### PR TITLE
Fixed a bug where customs fields belonging to a custom section were not present in the data sent to docxtemplater

### DIFF
--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -922,7 +922,8 @@ async function prepAuditData(data, settings) {
         }
         if (section.text) // keep text for retrocompatibility
             formatSection.text = await splitHTMLParagraphs(section.text)
-        else if (section.customFields) {
+        // If only because section has "any" inside its text attribute and then skip the section.customFields
+        if (section.customFields) {
             for (field of section.customFields) {
                 var fieldType = field.customField.fieldType
                 var label = field.customField.label


### PR DESCRIPTION
Hey, 
Fixed a bug where the custom fields of a custom section were skipped during the parsing.
Line. 923, we check if the section has a "text" attribute, if not we parse customFields
![image](https://github.com/pwndoc-ng/pwndoc-ng/assets/49342114/9ed79c5f-b8ba-4a3d-87eb-5c2cd4e98667)

But there is a case where a custom section has a text attribute set to "any" **and also** customfields.
![image](https://github.com/pwndoc-ng/pwndoc-ng/assets/49342114/9a9c5105-8742-4139-8ecb-c6e8b66692d8)

The fix only aims to take both in the final result.
![image](https://github.com/pwndoc-ng/pwndoc-ng/assets/49342114/8514fcc9-20bc-470c-b75c-13d66d44f3c9)
