### PR TITLE
allow setting secrets through env vars

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -17,11 +17,9 @@ var utils = require('./lib/utils');
 const swaggerUi = require('swagger-ui-express');
 const swaggerDocument = require('./config/swagger-output.json');
 
-
-
 // Get configuration
-var env = process.env.NODE_ENV || 'dev';
-var config = require('./config/config.json')[env];
+const config = require('./lib/config-loader').config;
+
 global.__basedir = __dirname;
 
 // Database connection

--- a/backend/src/lib/auth.js
+++ b/backend/src/lib/auth.js
@@ -1,23 +1,11 @@
 // Dynamic generation of JWT Secret if not exist (different for each environnment)
-var fs = require('fs')
-var env = process.env.NODE_ENV || 'dev'
-var config = require('../config/config.json')
+const fs = require('fs')
+const config = require('./config-loader').config
 
-if (!config[env].jwtSecret) {
-    config[env].jwtSecret = require('crypto').randomBytes(32).toString('hex')
-    var configString = JSON.stringify(config, null, 4)
-    fs.writeFileSync(`${__basedir}/config/config.json`, configString)
-}
-if (!config[env].jwtRefreshSecret) {
-    config[env].jwtRefreshSecret = require('crypto').randomBytes(32).toString('hex')
-    var configString = JSON.stringify(config, null, 4)
-    fs.writeFileSync(`${__basedir}/config/config.json`, configString)
-}
-
-var jwtSecret = config[env].jwtSecret
+var jwtSecret = config.jwtSecret
 exports.jwtSecret = jwtSecret
 
-var jwtRefreshSecret = config[env].jwtRefreshSecret
+var jwtRefreshSecret = config.jwtRefreshSecret
 exports.jwtRefreshSecret = jwtRefreshSecret
 
 /*  ROLES LOGIC

--- a/backend/src/lib/config-loader.js
+++ b/backend/src/lib/config-loader.js
@@ -1,0 +1,43 @@
+const fs = require("fs");
+const env = process.env.NODE_ENV || 'dev'
+const configJSON = require('../config/config.json')
+
+let currentConfig = configJSON[env];
+if (process.env.JWT_SECRET && process.env.JWT_REFRESH_SECRET) {
+    currentConfig.jwtSecret = process.env.JWT_SECRET;
+    currentConfig.jwtRefreshSecret = process.env.JWT_REFRESH_SECRET;
+} else if (env === "prod") {
+
+    if (process.env.PROD_JWT_SECRET && process.env.PROD_JWT_REFRESH_SECRET) {
+        currentConfig.jwtSecret = process.env.PROD_JWT_SECRET;
+        currentConfig.jwtRefreshSecret = process.env.PROD_JWT_REFRESH_SECRET;
+    }
+} else if (env === "dev") {
+
+    if (process.env.DEV_JWT_SECRET && process.env.DEV_JWT_REFRESH_SECRET) {
+        currentConfig.jwtSecret = process.env.DEV_JWT_SECRET;
+        currentConfig.jwtRefreshSecret = process.env.DEV_JWT_REFRESH_SECRET;
+    }
+} else if (env === "test") {
+
+    if (process.env.TEST_JWT_SECRET && process.env.TEST_JWT_REFRESH_SECRET) {
+        currentConfig.jwtSecret = process.env.TEST_JWT_SECRET;
+        currentConfig.jwtRefreshSecret = process.env.TEST_JWT_REFRESH_SECRET;
+    }
+}
+
+if (!currentConfig.jwtSecret) {
+    configJSON[env].jwtSecret = require('crypto').randomBytes(32).toString('hex')
+    var configString = JSON.stringify(configJSON, null, 4)
+    fs.writeFileSync(`${__basedir}/config/config.json`, configString)
+    currentConfig.jwtSecret = configJSON[env].jwtSecret
+}
+
+if (!currentConfig.jwtRefreshSecret) {
+    configJSON[env].jwtRefreshSecret = require('crypto').randomBytes(32).toString('hex')
+    var configString = JSON.stringify(configJSON, null, 4)
+    fs.writeFileSync(`${__basedir}/config/config.json`, configString)
+    currentConfig.jwtRefreshSecret = configJSON[env].jwtRefreshSecret
+}
+
+exports.config = currentConfig

--- a/backend/tests/index.test.js
+++ b/backend/tests/index.test.js
@@ -1,9 +1,7 @@
 const request = require("supertest");
+const config = require('../src/lib/config-loader').config;
+const mongoose = require('mongoose');
 
-var env = process.env.NODE_ENV || 'dev';
-var config = require('../src/config/config.json')[env];
-
-var mongoose = require('mongoose');
 mongoose.connect(`mongodb://${config.database.server}:${config.database.port}/${config.database.name}`, {});
 
 /* Clean the DB */

--- a/docker-compose.override.example-dev.yml
+++ b/docker-compose.override.example-dev.yml
@@ -24,6 +24,9 @@ services:
       - ./backend/:/app/
     depends_on:
       - mongodb
+#    environment:
+#      JWT_SECRET: "put sweet random values here"
+#      JWT_REFRESH_SECRET: "put sweet random values here"
     restart: always
     links:
       - mongodb


### PR DESCRIPTION
This commit should allow configuring the JWT secrets through environment variables.

## Test Plan (requires docker compose)

- [ ] Checkout branch
- [ ] `cp docker-compose.override.example-dev.yml docker-compose.override.yml`
- [ ] Edit docker-compose.override.yml, uncomment environment variables and update the values to be nice and random
```bash
# sweet random generator
openssl rand 5000 | sha512sum | awk '{print $1}'
```
- [ ] docker compose up
- [ ] Visit https://localhost:8443/
- [ ] login and click around things should work
- [ ] run `git status` to ensure config.json was not auto-modified