### PR TITLE
Multiline codeblocks should work inside tables

### DIFF
--- a/backend/src/lib/html2ooxml.js
+++ b/backend/src/lib/html2ooxml.js
@@ -24,102 +24,124 @@ function html2ooxml(html, style = "") {
   let parser = new htmlparser.Parser(
     {
       onopentag(tag, attribs) {
-        if (tag === "h1") {
-          cParagraph = new docx.Paragraph({ heading: "Heading1" });
-        } else if (tag === "h2") {
-          cParagraph = new docx.Paragraph({ heading: "Heading2" });
-        } else if (tag === "h3") {
-          cParagraph = new docx.Paragraph({ heading: "Heading3" });
-        } else if (tag === "h4") {
-          cParagraph = new docx.Paragraph({ heading: "Heading4" });
-        } else if (tag === "h5") {
-          cParagraph = new docx.Paragraph({ heading: "Heading5" });
-        } else if (tag === "h6") {
-          cParagraph = new docx.Paragraph({ heading: "Heading6" });
-        } else if (tag === "div" || tag === "p") {
-          if (style && typeof style === 'string')
-            cParagraphProperties.style = style
-          cParagraph = new docx.Paragraph(cParagraphProperties)
-        } else if (tag === "table") {
-          inTable = true;
-        } else if (tag === "td") {
-          tmpAttribs = attribs;
-          inTableCell = true;
-          cellHasText = false;
-          tmpCellContent = [];
-        } else if (tag === "th") {
-          inTableCell = true;
-          tableHeader = true;
-          tmpAttribs = attribs;
-          tmpCellContent = [];
-          cellHasText = false;
-        } else if (tag === "tr") {
-          inTableRow = true;
-        } else if (tag === "pre") {
-          inCodeBlock = true;
-          cParagraph = new docx.Paragraph({ style: "Code" });
-        } else if (tag === "br") {
-          if (inCodeBlock) {
-            paragraphs.push(cParagraph)
-            cParagraph = new docx.Paragraph({ style: "Code" })
-          } else {
-            cParagraph.addChildElement(new docx.Run({ break: 1 }))
-          }
-        } else if (tag === "b" || tag === "strong") {
-          cRunProperties.bold = true;
-        } else if (tag === "i" || tag === "em") {
-          cRunProperties.italics = true;
-        } else if (tag === "u") {
-          cRunProperties.underline = {};
-        } else if (tag === "strike" || tag === "s") {
-          cRunProperties.strike = true;
-        } else if (tag === "mark") {
-          //Possible values are: black, blue, cyan, darkBlue, darkCyan, darkGray, darkGreen, darkMagenta, darkRed, darkYellow, green, lightGray, magenta, none, red, white, yellow
-          let color;
-          switch (attribs["data-color"]) {
-            case "#ffff00":
-              color = "yellow";
-              break;
-            case "#fe0000":
-              color = "red";
-              break;
-            case "#00ff00":
-              color = "green";
-              break;
-            case "#00ffff":
-              color = "cyan";
-              break;
-          }
-          cRunProperties.highlight = color;
-        } else if (tag === "a") {
-          cRunProperties.link = attribs.href;
-        } else if (tag === "br") {
-          if (inCodeBlock) {
-            paragraphs.push(cParagraph);
+        switch (tag) {
+          case 'h1':
+            cParagraph = new docx.Paragraph({ heading: "Heading1" });
+            break;
+          case 'h2':
+            cParagraph = new docx.Paragraph({ heading: "Heading2" });
+            break;
+          case 'h3':
+            cParagraph = new docx.Paragraph({ heading: "Heading3" });
+            break;
+          case 'h4':
+            cParagraph = new docx.Paragraph({ heading: "Heading4" });
+            break;
+          case 'h5':
+            cParagraph = new docx.Paragraph({ heading: "Heading5" });
+            break;
+          case 'h6':
+            cParagraph = new docx.Paragraph({ heading: "Heading6" });
+            break;
+          case 'div':
+          case 'p':
+            if (style && typeof style === 'string') {
+              cParagraphProperties.style = style
+            }
+            cParagraph = new docx.Paragraph(cParagraphProperties)
+            break;
+          case 'table':
+            inTable = true;
+            break;
+          case 'td':
+            tmpAttribs = attribs;
+            inTableCell = true;
+            cellHasText = false;
+            tmpCellContent = [];
+            break;
+          case 'th':
+            inTableCell = true;
+            tableHeader = true;
+            tmpAttribs = attribs;
+            tmpCellContent = [];
+            cellHasText = false;
+            break;
+          case 'tr':
+            inTableRow = true;
+            break;
+          case 'pre':
+            inCodeBlock = true;
             cParagraph = new docx.Paragraph({ style: "Code" });
-          } else cParagraph.addChildElement(new docx.Run({ break: 1 }));
-        } else if (tag === "ul") {
-          list_state.push("bullet");
-        } else if (tag === "ol") {
-          list_state.push("number");
-        } else if (tag === "li") {
-          let level = list_state.length - 1;
-          if (level >= 0 && list_state[level] === "bullet")
-            cParagraphProperties.bullet = { level: level };
-          else if (level >= 0 && list_state[level] === "number")
-            cParagraphProperties.numbering = { reference: 2, level: level };
-          else cParagraphProperties.bullet = { level: 0 };
-        } else if (tag === "code") {
-          cRunProperties.style = "CodeChar";
-        } else if (tag === "legend" && attribs && attribs.alt !== "undefined") {
-          let label = attribs.label || "Figure";
-          cParagraph = new docx.Paragraph({
-            style: "Caption",
-            alignment: docx.AlignmentType.CENTER,
-          });
-          cParagraph.addChildElement(new docx.TextRun(`${label} `));
-          cParagraph.addChildElement(new docx.SimpleField(`SEQ ${label}`, "1"));
-          cParagraph.addChildElement(new docx.TextRun(` - ${attribs.alt}`));
+            break;
+          case 'br':
+            cParagraph.addChildElement(new docx.Run({ break: 1 }))
+            break;
+          case 'b':
+          case 'strong':
+            cRunProperties.bold = true;
+            break;
+          case 'i':
+          case 'em':
+            cRunProperties.italics = true;
+            break;
+          case 'u':
+            cRunProperties.underline = {};
+            break;
+          case 'strike':
+          case 's':
+            cRunProperties.strike = true;
+            break;
+          case 'mark':
+            //Possible values are: black, blue, cyan, darkBlue, darkCyan, darkGray, darkGreen, darkMagenta, darkRed, darkYellow, green, lightGray, magenta, none, red, white, yellow
+            let color;
+            switch (attribs["data-color"]) {
+              case "#ffff00":
+                color = "yellow";
+                break;
+              case "#fe0000":
+                color = "red";
+                break;
+              case "#00ff00":
+                color = "green";
+                break;
+              case "#00ffff":
+                color = "cyan";
+                break;
+            }
+            cRunProperties.highlight = color;
+            break;
+          case 'a':
+            cRunProperties.link = attribs.href;
+            break;
+          case 'ul':
+            list_state.push("bullet");
+            break;
+          case 'ol':
+            list_state.push("number");
+            break;
+          case 'li':
+            let level = list_state.length - 1;
+            if (level >= 0 && list_state[level] === "bullet")
+              cParagraphProperties.bullet = { level: level };
+            else if (level >= 0 && list_state[level] === "number")
+              cParagraphProperties.numbering = { reference: 2, level: level };
+            else cParagraphProperties.bullet = { level: 0 };
+            break;
+          case 'code':
+            cRunProperties.style = "CodeChar";
+            break;
+          case 'legend':
+            if (attribs && attribs.alt !== "undefined") {
+              let label = attribs.label || "Figure";
+              cParagraph = new docx.Paragraph({
+                style: "Caption",
+                alignment: docx.AlignmentType.CENTER,
+              });
+              cParagraph.addChildElement(new docx.TextRun(`${label} `));
+              cParagraph.addChildElement(new docx.SimpleField(`SEQ ${label}`, "1"));
+              cParagraph.addChildElement(new docx.TextRun(` - ${attribs.alt}`));
+            }
+            break;
         }
       },
 


### PR DESCRIPTION
Sorry for the large diff. The large if/elseif was hard to read and determine if there are duplicates. so I migrated to a switch. This probably needs #344, since I was unable to build without that change.

essentially this changes this:
```js
        } else if (tag === "br") {
          if (inCodeBlock) {
            paragraphs.push(cParagraph)
            cParagraph = new docx.Paragraph({ style: "Code" })
          } else {
            cParagraph.addChildElement(new docx.Run({ break: 1 }))
          }
        }
```

to this 
```js
        } else if (tag === "br") {
            cParagraph.addChildElement(new docx.Run({ break: 1 }))
        }
```

- This fixes #304
- This refactored a large many multi if/elseif block to a single switch
- This uncovered a duplicate tag handler for the br tag which was never used.
- I removed code that seemed like it was there for a reason, maybe the better tag context made that logic moot.

*Test Plan*

- [ ] test all the things report generation.....