### PR TITLE
Missing description and observation fix

### DIFF
--- a/docker-compose.override.example-dev.yml
+++ b/docker-compose.override.example-dev.yml
@@ -21,7 +21,13 @@ services:
     working_dir: "/app"
     command: "npm run dev"
     volumes:
-      - ./backend/:/app/
+      - ./backend/src/:/app/src/
+      - ./backend/report-templates/:/app/report-templates/
+      - ./backend/ssl/:/app/ssl/
+      - ./backend/tests/:/app/tests/
+      - ./backend/package.json:/app/package.json
+      - ./backend/package-lock.json:/app/package-lock.json
+      - ./backend/swagger.js:/app/swagger.js
     depends_on:
       - mongodb
     restart: always
@@ -42,8 +48,6 @@ services:
       - ./frontend/package.json:/app/package.json
       - ./frontend/package-lock.json:/app/package-lock.json
     restart: always
-    networks:
-      - backend
     links:
       - backend
 
@@ -54,6 +58,8 @@ services:
       - ./frontend/.docker/nginx.dev.conf:/etc/nginx/conf.d/default.conf
       - ./frontend/ssl:/etc/nginx/ssl/
     restart: always
+    ports:
+      - 8443:8443
     links:
       - frontend-app
       - backend

--- a/frontend/src/components/editor.vue
+++ b/frontend/src/components/editor.vue
@@ -722,7 +722,6 @@ export default {
           this.countChange++
         }
         
-        if (this.noSync) return;
         this.updateHTML();
       },
       disableInputRules: true,
@@ -909,6 +908,7 @@ export default {
       return colour;
     },
     updateHTML() {
+      if (this.noSync) return;
       console.log("updateHTML");
       this.json = this.editor.getJSON();
       this.html = this.editor.getHTML();

--- a/frontend/src/components/editor.vue
+++ b/frontend/src/components/editor.vue
@@ -731,8 +731,12 @@ export default {
     this.affixRelativeElement += "-" +  this.ClassEditor;
     //this.editor.setOptions({ editable: this.editable });
     this.editor.setEditable(this.editable && this.initialeDataUpdated);
+    
+    if (typeof this.value === "undefined") {
+      this.value = "";
+    }
+
     if (
-      typeof this.value === "undefined" ||
       this.value === this.editor.getHTML()
     ) {
       return;

--- a/frontend/src/components/editor.vue
+++ b/frontend/src/components/editor.vue
@@ -721,7 +721,8 @@ export default {
         } else {
           this.countChange++
         }
-        
+
+        if (this.noSync) return;
         this.updateHTML();
       },
       disableInputRules: true,
@@ -908,7 +909,8 @@ export default {
       return colour;
     },
     updateHTML() {
-      if (this.noSync) return;
+      if (!this.initialeDataUpdated) return;
+      
       console.log("updateHTML");
       this.json = this.editor.getJSON();
       this.html = this.editor.getHTML();

--- a/frontend/src/pages/audits/edit/findings/edit/edit.js
+++ b/frontend/src/pages/audits/edit/findings/edit/edit.js
@@ -255,7 +255,7 @@ export default {
         },
 
         syncEditors: function() {
-            Utils.syncEditors(this.$refs)
+            Utils.syncEditors(this.$refs);
         },
 
         updateOrig: function() {

--- a/frontend/src/pages/vulnerabilities/vulnerabilities.html
+++ b/frontend/src/pages/vulnerabilities/vulnerabilities.html
@@ -107,7 +107,7 @@
                         v-model="search.updatedAt"
                         outlined
                         mask="##-##-####"
-                        >
+                        />
                     </q-td>
                     <q-td></q-td>
                 </q-tr>


### PR DESCRIPTION
There was a problem with disappearing description and observation caused by manual sync for editors set as noSync.
To fix this, simply move the noSync check from the onUpdate event to the updateHTML method.
Closes #347 and again fixed and closed #280