### PR TITLE
fix: fix sync collab on customfield richtext

### DIFF
--- a/frontend/src/components/custom-fields.vue
+++ b/frontend/src/components/custom-fields.vue
@@ -22,14 +22,14 @@
                         v-if="diff"
                         v-model="field.text"
                         v-on:editorchange="eventPropagation"
-                        :idUnique="field.customField._id"
+                        :idUnique="field.customField._id+'-custom-'+idUnique"
                         :diff="getTextDiffInCustomFields(field)"
                         :editable=false
                         :collab="collab"
                         /> 
                         <basic-editor 
                         v-else
-                        :idUnique="field.customField._id"
+                        :idUnique="field.customField._id+'-custom-'+idUnique"
                         v-on:editorchange="eventPropagation"
                         ref="basiceditor_custom" 
                         v-model="field.text" 
@@ -244,6 +244,10 @@ export default {
         collab: {
             type: Boolean,
             default: true
+        },
+        idUnique: {
+            type: String,
+            default: ''
         }
     },
 

--- a/frontend/src/pages/vulnerabilities/vulnerabilities.html
+++ b/frontend/src/pages/vulnerabilities/vulnerabilities.html
@@ -292,7 +292,8 @@
             :key="currentDetailsIndex"
             :disabled="lenCurrentTitle === 0"
             :readonly="lenCurrentTitle === 0"
-            :category="currentVulnerability.category" 
+            :category="currentVulnerability.category"
+            :idUnique="currentDetailsIndex+currentVulnerability._id" 
             custom-element="QCardSection"
             display="vuln"
             :locale="currentLanguage"
@@ -455,10 +456,11 @@
         default-opened
         header-class="bg-blue-grey-5 text-white" 
         expand-icon-class="text-white">
-            <custom-fields 
+          <custom-fields
             ref="customfields" 
             v-model="currentVulnerability.details[currentDetailsIndex].customFields"
             :key="currentDetailsIndex"
+            :idUnique="currentDetailsIndex+currentVulnerability._id"
             :disabled="lenCurrentTitle === 0"
             :readonly="lenCurrentTitle === 0"
             custom-element="QCardSection"
@@ -605,7 +607,8 @@
                             <custom-fields 
                             ref="customfields" 
                             v-model="currentVulnerability.details[currentDetailsIndex].customFields"
-                            :key="currentDetailsIndex" 
+                            :key="currentDetailsIndex"
+                            :idUnique="currentDetailsIndex+currentVulnerability._id" 
                             :disabled="lenCurrentTitle === 0" :readonly="lenCurrentTitle === 0" 
                             custom-element="QCardSection"
                             :locale="currentLanguage"
@@ -794,7 +797,8 @@
                                 <div v-if="update.customFields">
                                     <custom-fields 
                                     ref="customfields" 
-                                    v-model="update.customFields" 
+                                    v-model="update.customFields"
+                                    :idUnique="currentDetailsIndex+currentVulnerability._id" 
                                     custom-element="QCardSection"
                                     :diff="currentVulnerability.details[currentDetailsIndex].customFields"
                                     :locale="currentLanguage"


### PR DESCRIPTION
The custom fields in the database do not depend on an audit or a vulnerability. When a vulnerability contains a custom field as a richtext and it is edited in two different tabs, a sync bug occurs. Making all custom fields of the same value as one obtained.

This bug stems from the fact that a customfield will be referenced by an id that does not depend on the audit or vulnerability that is being edited. The id will always be the same when it is used with the hocuspocus server's websocket.

See video below.

https://github.com/pwndoc-ng/pwndoc-ng/assets/28403617/865fbd6f-c31f-4b44-a3b0-880d78b64d77

This PR fixes this problem by adding a prop `idUnique` that depends on both the vulnerability being edited and the language.