### PR TITLE
fix: #203

### DIFF
--- a/frontend/src/pages/vulnerabilities/vulnerabilities.html
+++ b/frontend/src/pages/vulnerabilities/vulnerabilities.html
@@ -694,7 +694,6 @@
                                     <template v-slot="control">
                                         <basic-editor noAffix 
                                         v-model="update.description" 
-                                        :idUnique="currentVulnerability._id+'-description'"
                                         :diff="currentVulnerability.details[currentDetailsIndex].description || ''" 
                                         :editable=false />
                                     </template>
@@ -715,7 +714,6 @@
                                     <template v-slot="control">
                                         <basic-editor noAffix 
                                         v-model="update.observation"
-                                        :idUnique="currentVulnerability._id+'-observation'"
                                         :diff="currentVulnerability.details[currentDetailsIndex].observation || ''"
                                         :editable=false />
                                     </template>
@@ -744,7 +742,6 @@
                                     <template v-slot="control">
                                         <basic-editor noAffix 
                                         v-model="update.remediation" 
-                                        :idUnique="currentVulnerability._id+'-remediation'"
                                         :diff="currentVulnerability.details[currentDetailsIndex].remediation || ''"
                                         :editable=false />
                                     </template>


### PR DESCRIPTION
This PR fix #203 

The editors which show update suggestions were getting overridden by the editor which show the original content because they were sharing the same idUnique. 