### PR TITLE
Added new API endpoint

### DIFF
--- a/backend/src/config/swagger-output.json
+++ b/backend/src/config/swagger-output.json
@@ -5,10 +5,10 @@
     "description": "",
     "version": "1.0.0"
   },
-  "host": "/",
+  "host": "localhost:8443",
   "basePath": "/",
   "schemes": [
-    "http"
+    "http","https"
   ],
   "paths": {
     "/api/audits": {
@@ -207,6 +207,16 @@
             }
           }
         ],
+        "responses": {}
+      }
+    },
+    "/api/audits/findings": {
+      "get": {
+        "tags": [
+          "Audit"
+        ],
+        "description": "",
+        "parameters": [],
         "responses": {}
       }
     },

--- a/backend/src/routes/audit.js
+++ b/backend/src/routes/audit.js
@@ -94,6 +94,14 @@ module.exports = function(app, io) {
     })
 
     /* ### AUDITS EDIT ### */
+    
+    // Get Audit and Findings in a single endpoint
+    app.get("/api/audits/findings", acl.hasPermission('audits:read'), function(req, res) {
+
+        Audit.getAllAuditFindings(acl.isAllowed(req.decodedToken.role, 'audits:read-all'), req.decodedToken.id)
+        .then(msg => Response.Ok(res, msg))
+        .catch(err => Response.Internal(res, err))
+    });
 
     // Get Audit with ID
     app.get("/api/audits/:auditId", acl.hasPermission('audits:read'), function(req, res) {


### PR DESCRIPTION
- Added a new API endpoint to group all assessment findings in a single endpoint "/api/audits/findings"
- Updated the API documentation (swagger-output.json) to reflect the added endpoint
- Added the HTTPS protocol to the swagger config file (swagger-output.json) 
- Updated the base URL of the swagger config file (swagger-output.json) form "/" to "localhost:8443"