### PR TITLE
Fixed the bug that removed the scope elements from the network scan tab FIX #494

### DIFF
--- a/frontend/src/pages/audits/edit/network/network.js
+++ b/frontend/src/pages/audits/edit/network/network.js
@@ -127,7 +127,7 @@ export default {
         getAuditGeneral: function() {
             DataService.getCustomFields()
             .then((data) => {
-                this.audit = data.data.datas;
+                this.audit.customFields = data.data.datas.customFields;
             })
             .catch((err) => {              
                 console.log(err.response)


### PR DESCRIPTION
This will fix #494
But there is still a bug, when we click on the imported scope it should print on the right the open ports, but this is not showned