### PR TITLE
Update dump to hide Delete buttons from non-admin

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.0.0-alpine3.16
+FROM node:20-alpine
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20.0.0-alpine3.16
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/frontend/src/pages/data/dump/dump.html
+++ b/frontend/src/pages/data/dump/dump.html
@@ -48,7 +48,7 @@
                             </q-item>
                         </div>
                     </q-card-section>
-                    <q-card-section class="row">
+                    <q-card-section class="row" v-if="isAdmin">
                         <div class="col-md-6 col-12" >
                             <div class="text-bold">{{$t('deleteAllVulnerabilities')}}</div>
                             <div class="text-grey-8" v-html="$t('deleteAllVulnerabilitiesInfo')"></div>
@@ -106,7 +106,7 @@
                             </q-item>
                         </div>
                     </q-card-section>
-                    <q-card-section class="row">
+                    <q-card-section class="row" v-if="isAdmin">
                         <div class="col-md-6 col-12" >
                             <div class="text-bold">{{$t('deleteAllCompanies')}}</div>
                             <div class="text-grey-8" v-html="$t('deleteAllCompaniesInfo')"></div>
@@ -162,7 +162,7 @@
                             </q-item>
                         </div>
                     </q-card-section>
-                    <q-card-section class="row">
+                    <q-card-section class="row" v-if="isAdmin">
                         <div class="col-md-6 col-12" >
                             <div class="text-bold">{{$t('deleteAllClients')}}</div>
                             <div class="text-grey-8" v-html="$t('deleteAllClientsInfo')"></div>

--- a/frontend/src/pages/data/dump/dump.js
+++ b/frontend/src/pages/data/dump/dump.js
@@ -23,11 +23,29 @@ export default {
             UserService: UserService,
             vulnerabilities: [],
             selectedTab: "vulnerabilities",
+            user: null
         }
     },
 
     mounted: function() {
-        
+        // Load current user profile to drive role-based UI (e.g. hide dangerous actions)
+        UserService.getProfile()
+        .then((data) => {
+            // Store the full user object including role
+            // so we can use it in the template via isAdmin
+            this.user = data.data.datas;
+        })
+        .catch((err) => {
+            // In case of error, just log it; backend authorization
+            // still protects the destructive endpoints
+            console.log(err);
+        });
+    },
+
+    computed: {
+        isAdmin: function() {
+            return this.user && this.user.role === 'admin';
+        }
     },
 
     methods: {


### PR DESCRIPTION
I’ve implemented the role-based hiding of the destructive “delete all” UI on the dump page.

### 1. Role-aware state and helper in the dump component

In [`frontend/src/pages/data/dump/dump.js`](frontend/src/pages/data/dump/dump.js):

- **Added user state** to `data()` so the dump page can know the current user’s role:

```js
export default {
  data: () => {
    return {
      UserService: UserService,
      vulnerabilities: [],
      selectedTab: 'vulnerabilities',
      user: null
    }
  },
  // ...
}
```

- **Populated `user` on mount** using the same pattern as the profile page:

```js
mounted: function () {
  // Load current user profile to drive role-based UI (e.g. hide dangerous actions)
  UserService.getProfile()
    .then((data) => {
      // Store the full user object including role
      // so we can use it in the template via isAdmin
      this.user = data.data.datas
    })
    .catch((err) => {
      // In case of error, just log it; backend authorization
      // still protects the destructive endpoints
      console.log(err)
    })
},
```

- **Defined a computed helper** [`isAdmin()`](frontend/src/pages/data/dump/dump.js:1) used by the template to guard destructive UI:

```js
computed: {
  isAdmin: function () {
    return this.user && this.user.role === 'admin'
  }
},
```

All existing delete methods (`deleteAllVulnerabilities`, `deleteAllCompanies`, `deleteAllClients`, `deleteAllUsers`) remain unchanged and still call the same backend services.

### 2. Hiding the “delete all” sections in the template

In [`frontend/src/pages/data/dump/dump.html`](frontend/src/pages/data/dump/dump.html), the “delete all” sections are now wrapped with `v-if="isAdmin"` so **only admins see them**.

Specifically:

- **Vulnerabilities – delete all** section:

```html
<q-card-section class="row" v-if="isAdmin">
  <div class="col-md-6 col-12">
    <div class="text-bold">{{$t('deleteAllVulnerabilities')}}</div>
    <div class="text-grey-8" v-html="$t('deleteAllVulnerabilitiesInfo')"></div>
    <q-item>
      <q-btn
        :label="$t('btn.deleteAll')"
        flat
        class="bg-negative text-white"
        @click="deleteAllVulnerabilities"
      />
    </q-item>
  </div>
</q-card-section>
```

- **Companies – delete all** section:

```html
<q-card-section class="row" v-if="isAdmin">
  <div class="col-md-6 col-12">
    <div class="text-bold">{{$t('deleteAllCompanies')}}</div>
    <div class="text-grey-8" v-html="$t('deleteAllCompaniesInfo')"></div>
    <q-item>
      <q-btn
        :label="$t('btn.deleteAll')"
        flat
        class="bg-negative text-white"
        @click="deleteAllCompanies"
      />
    </q-item>
  </div>
</q-card-section>
```

- **Clients – delete all** section:

```html
<q-card-section class="row" v-if="isAdmin">
  <div class="col-md-6 col-12">
    <div class="text-bold">{{$t('deleteAllClients')}}</div>
    <div class="text-grey-8" v-html="$t('deleteAllClientsInfo')"></div>
    <q-item>
      <q-btn
        :label="$t('btn.deleteAll')"
        flat
        class="bg-negative text-white"
        @click="deleteAllClients"
      />
    </q-item>
  </div>
</q-card-section>
```

The import/export sections remain visible to all roles; only the **dangerous “delete all” blocks** are now role-gated.

### 3. Behavior summary

- When a user opens the **Data → Dump** page:
  - The component calls `UserService.getProfile()`, stores the result in `this.user`, and computes `isAdmin`.
- For **non-admins**:
  - `isAdmin` is `false`, so the “delete all vulnerabilities/companies/clients” sections are not rendered at all.
- For **admins**:
  - `isAdmin` is `true`, so they see and can use all existing destructive actions exactly as before.
- Backend authorization is unchanged and should still enforce permissions server-side.

This completes the requested change: all titles, sections, and buttons for the dangerous “delete all” commands on the dump page are now hidden for non-admin users, using the same `user.role` concept already used on the profile page.